### PR TITLE
wirelesstag: Dropped Errors

### DIFF
--- a/wirelesstag/wirelesstag.go
+++ b/wirelesstag/wirelesstag.go
@@ -189,6 +189,9 @@ func GetTags(clientId string, clientSecret string) ([]Tag, error) {
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read response: %v", err)
+	}
 	resp.Body.Close()
 
 	var tags TagList

--- a/wirelesstag/wirelesstag.go
+++ b/wirelesstag/wirelesstag.go
@@ -227,6 +227,9 @@ func GetLogs(clientId string, clientSecret string) (map[string]map[string][]floa
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read response: %v", err)
+	}
 	resp.Body.Close()
 
 	var logs StatsResponse


### PR DESCRIPTION
This fixes two dropped `err` variables in the `wirelesstag` package.